### PR TITLE
Add folder right-click option (and uninstall .reg); document.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # Right click "Bash-here" Shortcut in Context Menu for MSYS2 MINGW32/64 shell
-This is all the configuration files needed for adding "bash here" options in 
-the Windows right-click shortcut/context menu. 
+This is all the configuration files needed for adding "bash here" options in the Windows right-click shortcut/context menu. The menu options will be made available for both right-click on a folder background and [right-click on a folder](https://gist.github.com/magthe/a60293fe395af7245a9e#gistcomment-3164952).
 
 This implementation should work for MSYS2 and MINGW32/64 shells that come with MSYS2.
 
@@ -9,8 +8,7 @@ This implementation should work for MSYS2 and MINGW32/64 shells that come with M
 
 
 ## Usage
-0. Make sure the environment variable `$HOME` exists and points to `/home/<userid>` from your MSYS2/bash console. 
-   (This script will source `$HOME/.bash_profile`)
+0. Make sure the environment variable `$HOME` exists and points to `/home/<userid>` from your MSYS2/bash console. To test this, opening an MSYS2/bash console, and type and run this command: `echo $HOME`. If it prints a valid path, the variable exists with a valid value. If it does not print a path, you need to fix up your install to include a `$HOME` environment variable (out of scope of this document). This is needed because this script will source `$HOME/.bash_profile`. Then, from an MSYS2/bash console, run these commands:
 1. `$ git clone git@github.com:njzhangyifei/msys2-mingw-shortcut-menus.git` into
    your desired directory to install
    - Or `git clone https://github.com/njzhangyifei/msys2-mingw-shortcut-menus.git`

--- a/install
+++ b/install
@@ -124,11 +124,21 @@ UNINS_REG_FILE="uninstall_right_click_menu.reg"
 cat <<EOF >${UNINS_REG_FILE}
 Windows Registry Editor Version 5.00
 
+;; THIS SECTION removes right-click on folder background options.
 [-HKEY_CLASSES_ROOT\Directory\Background\shell\mingw32]
 
 [-HKEY_CLASSES_ROOT\Directory\Background\shell\mingw64]
 
 [-HKEY_CLASSES_ROOT\Directory\Background\shell\msys2]
+
+
+;; THIS SECTION removes right-click on folder options.
+[-HKEY_CLASSES_ROOT\Directory\shell\mingw32]
+
+[-HKEY_CLASSES_ROOT\Directory\shell\mingw64]
+
+[-HKEY_CLASSES_ROOT\Directory\shell\msys2]
+
 EOF
 
 echo

--- a/reg_aio_bash_msys2_shell.template
+++ b/reg_aio_bash_msys2_shell.template
@@ -1,5 +1,6 @@
 Windows Registry Editor Version 5.00
 
+;; THIS SECTION is for right-click on a folder background.
 [HKEY_CLASSES_ROOT\Directory\Background\shell\mingw32]
 @="MinGW &32 Bash Here"
 "Icon"="\"{MSYS2_INSTALL_DIR}mingw32.exe\""
@@ -21,3 +22,25 @@ Windows Registry Editor Version 5.00
 [HKEY_CLASSES_ROOT\Directory\Background\shell\msys2\command]
 @="{MSYS2_INSTALL_DIR}msys2_shell.cmd -msys -here \"%v\""
 
+
+;; THIS SECTION is for right-click on a folder.
+[HKEY_CLASSES_ROOT\Directory\shell\mingw32]
+@="MinGW &32 Bash Here"
+"Icon"="\"{MSYS2_INSTALL_DIR}mingw32.exe\""
+
+[HKEY_CLASSES_ROOT\Directory\shell\mingw32\command]
+@="{MSYS2_INSTALL_DIR}msys2_shell.cmd -mingw32 -here \"%v\""
+
+[HKEY_CLASSES_ROOT\Directory\shell\mingw64]
+@="MinGW 64 Ba&sh Here"
+"Icon"="\"{MSYS2_INSTALL_DIR}mingw64.exe\""
+
+[HKEY_CLASSES_ROOT\Directory\shell\mingw64\command]
+@="{MSYS2_INSTALL_DIR}msys2_shell.cmd -mingw64 -here \"%v\""
+
+[HKEY_CLASSES_ROOT\Directory\shell\msys2]
+@="MSYS2 Bash Here"
+"Icon"="\"{MSYS2_INSTALL_DIR}msys2.ico\""
+
+[HKEY_CLASSES_ROOT\Directory\shell\msys2\command]
+@="{MSYS2_INSTALL_DIR}msys2_shell.cmd -msys -here \"%v\""

--- a/reg_aio_zsh_msys2_shell_example.template
+++ b/reg_aio_zsh_msys2_shell_example.template
@@ -1,5 +1,6 @@
 Windows Registry Editor Version 5.00
 
+;; THIS SECTION is for right-click on a folder background.
 [HKEY_CLASSES_ROOT\Directory\Background\shell\mingw32]
 @="MinGW [&3]2 Zsh Here"
 "Icon"="\"{MSYS2_INSTALL_DIR}mingw32.exe\""
@@ -21,3 +22,25 @@ Windows Registry Editor Version 5.00
 [HKEY_CLASSES_ROOT\Directory\Background\shell\msys2\command]
 @="{MSYS2_INSTALL_DIR}msys2_shell_zsh.cmd -msys -here \"%v\""
 
+
+;; THIS SECTION is for right-click on a folder.
+[HKEY_CLASSES_ROOT\Directory\shell\mingw32]
+@="MinGW [&3]2 Zsh Here"
+"Icon"="\"{MSYS2_INSTALL_DIR}mingw32.exe\""
+
+[HKEY_CLASSES_ROOT\Directory\shell\mingw32\command]
+@="{MSYS2_INSTALL_DIR}msys2_shell_zsh.cmd -mingw32 -here \"%v\""
+
+[HKEY_CLASSES_ROOT\Directory\shell\mingw64]
+@="MinGW 64 Z[&s]h Here"
+"Icon"="\"{MSYS2_INSTALL_DIR}mingw64.exe\""
+
+[HKEY_CLASSES_ROOT\Directory\shell\mingw64\command]
+@="{MSYS2_INSTALL_DIR}msys2_shell_zsh.cmd -mingw64 -here \"%v\""
+
+[HKEY_CLASSES_ROOT\Directory\shell\msys2]
+@="[&M]SYS2 Zsh Here"
+"Icon"="\"{MSYS2_INSTALL_DIR}msys2.ico\""
+
+[HKEY_CLASSES_ROOT\Directory\shell\msys2\command]
+@="{MSYS2_INSTALL_DIR}msys2_shell_zsh.cmd -msys -here \"%v\""

--- a/reg_mingw32.template
+++ b/reg_mingw32.template
@@ -1,3 +1,4 @@
+;; THIS SECTION is for right-clock on a folder background.
 [HKEY_CLASSES_ROOT\Directory\Background\shell\mingw32]
 @="MinGW &32 Bash Here"
 "Icon"="\"{MSYS2_INSTALL_DIR}mingw32.exe\""
@@ -5,3 +6,11 @@
 [HKEY_CLASSES_ROOT\Directory\Background\shell\mingw32\command]
 @="cmd /U /C \"{SCRIPT_HERE_PATH_WIN} \"%v\"\""
 
+
+;; THIS SECTION is for right-clock on a folder.
+[HKEY_CLASSES_ROOT\Directory\shell\mingw32]
+@="MinGW &32 Bash Here"
+"Icon"="\"{MSYS2_INSTALL_DIR}mingw32.exe\""
+
+[HKEY_CLASSES_ROOT\Directory\shell\mingw32\command]
+@="cmd /U /C \"{SCRIPT_HERE_PATH_WIN} \"%v\"\""

--- a/reg_mingw64.template
+++ b/reg_mingw64.template
@@ -1,3 +1,4 @@
+;; THIS SECTION is for right-clock on a folder background.
 [HKEY_CLASSES_ROOT\Directory\Background\shell\mingw64]
 @="MinGW 64 Ba&sh Here"
 "Icon"="\"{MSYS2_INSTALL_DIR}mingw64.exe\""
@@ -5,3 +6,11 @@
 [HKEY_CLASSES_ROOT\Directory\Background\shell\mingw64\command]
 @="cmd /U /C \"{SCRIPT_HERE_PATH_WIN} \"%v\"\""
 
+
+;; THIS SECTION is for right-clock on a folder.
+[HKEY_CLASSES_ROOT\Directory\shell\mingw64]
+@="MinGW 64 Ba&sh Here"
+"Icon"="\"{MSYS2_INSTALL_DIR}mingw64.exe\""
+
+[HKEY_CLASSES_ROOT\Directory\shell\mingw64\command]
+@="cmd /U /C \"{SCRIPT_HERE_PATH_WIN} \"%v\"\""

--- a/reg_msys2.template
+++ b/reg_msys2.template
@@ -1,3 +1,4 @@
+;; THIS SECTION is for right-clock on a folder background.
 [HKEY_CLASSES_ROOT\Directory\Background\shell\msys2]
 @="MSYS2 Bash Here"
 "Icon"="\"{MSYS2_INSTALL_DIR}msys2.ico\""
@@ -5,3 +6,11 @@
 [HKEY_CLASSES_ROOT\Directory\Background\shell\msys2\command]
 @="cmd /U /C \"{SCRIPT_HERE_PATH_WIN} \"%v\"\""
 
+
+;; THIS SECTION is for right-clock on a folder.
+[HKEY_CLASSES_ROOT\Directory\shell\msys2]
+@="MSYS2 Bash Here"
+"Icon"="\"{MSYS2_INSTALL_DIR}msys2.ico\""
+
+[HKEY_CLASSES_ROOT\Directory\shell\msys2\command]
+@="cmd /U /C \"{SCRIPT_HERE_PATH_WIN} \"%v\"\""


### PR DESCRIPTION
I customarily right-click on folders, not the backgrounds of folders, and I at first thought this didn't work because I saw no options on right-clicking a folder. Then I figured out it only creates folder _background_ right-click options.

So I added folder right-click options, and also updated the uninstaller registry template to remove them.